### PR TITLE
Fix make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,6 @@ _site
 # Vendor directory
 assets/vendor/
 
-# Ruby
-Gemfile.lock
-
 # Composer
 composer.lock
 <<<<<<< HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,11 @@
 source "https://rubygems.org"
 
 # Ruby Requirement
-# ruby '2.2.3'
+ruby '2.6.3'
 
 # Gem Requirements
 group :jekyll_plugins do
 	gem 'jekyll', '>=3.0'
-	gem 'sass'
 	gem 'jekyll-sitemap'
 	gem 'jekyll-paginate'
 	gem 'jekyll-figure'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,73 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.5)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.11.1)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.6)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-figure (0.1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-sitemap (1.3.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.1.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rouge (3.7.0)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (>= 3.0)
+  jekyll-figure
+  jekyll-paginate
+  jekyll-sitemap
+
+RUBY VERSION
+   ruby 2.6.3p62
+
+BUNDLED WITH
+   2.0.2

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 gulp = ./node_modules/gulp/bin/gulp.js
-preview :
-	$(gulp)
+# Creating the CSS needs to be run through Gulp
 
-deploy :
+clean :
+	rm -rf _site/*
+
+preview : clean
+	bundle exec jekyll serve --watch --drafts
+
+build : clean
 	@echo "Building site ..."
-	$(gulp) clean
-	$(gulp) build
+	bundle exec jekyll build
+
+deploy : build
+	@echo "Deploying to dev server ..."
+	rsync --checksum --delete --exclude appendices/ -avz \
+		_site/* athena:/websites/crdh/www/dev/
+
+deploy-production : build
 	@echo "Deploying to server ..."
 	rsync --checksum --delete --exclude appendices/ -avz \
 		_site/* athena:/websites/crdh/www/

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,6 @@ include:
   - "_pages"
 
 exclude:
-  - "/assets/"
   - "bower.json"
   - "composer.json"
   - "composer.lock"
@@ -36,6 +35,7 @@ exclude:
   - "node_modules"
   - "npm-debug.log"
   - "package.json"
+  - "package-lock.json"
   - "README.md"
   - "rev-manifest.json"
   - "yarn.lock"

--- a/_pages/conference/2019.md
+++ b/_pages/conference/2019.md
@@ -18,53 +18,63 @@ Location: Founders Hall 113
 
 This roundtable will feature four scholars in the field reflecting on
 developments in digital history in the preceding year, with commentary
-and discussion from conference attendees. Panelists to be named.
+and discussion from conference attendees. 
+
+- Denise Burgher, University of Delaware
+- Lauren Tilton, University of Richmond
+- Cameron Blevins, Northeastern University
 
 ### Paper session 1, 10:00--11:00 a.m.
 
-Session 1.1 — *Sponsored by the [Colored Conventions Project](http://coloredconventions.org)*
+Session 1.1 (Founders Hall 113) — *Sponsored by the [Colored Conventions Project](http://coloredconventions.org)*
 
 - P. Gabrielle Foreman, "Black Women and Digital Practices in the Age of the Archive: Oracle Protocols and Colored Conventions Project"
 - Jim Casey, "A Committee of the Whole"
 - Commentators: Denise Burgher and Anna Lacey
 
-Session 1.2 
+Session 1.2 (Founders Hall 311) 
 
 - Paul Reeve, "Century of Black Mormons: A Preliminary Interpretation of the Data"
 - Gianluca De Fazio, "Improving Lynching Inventories with Local Newspapers: Racial Terror in Virginia, 1877--1927"
+- Commentator: Anne Rubin
 
 ### Paper session 2, 11:10--12:10 p.m.
 
-Session 2.1 — *Sponsored by the [African American Intellectual History Society](https://www.aaihs.org/)*
+Session 2.1 (Founders Hall 113) — *Sponsored by the [African American Intellectual History Society](https://www.aaihs.org/)*
 
 - J. T. Roane and Justin Hosbey, "Mapping Black Ecologies"
 - Andrea Roberts and Mohammadjavad Biazar, "What Ever Happened to Freedom Colonies? Mapping Texas' African American Placemaking History
 (1865--1920)"
+- Commentator: Stephanie Lampkin
 
-Session 2.2 
+Session 2.2 (Founders Hall 311)  
 
 - Vilja Hulden, "Labor and Business at Congressional Hearings, 1877–1990: Unequal Power and the Significance of Elections"
 - Cameron Blevins, "Women and Federal Officeholding in the Late Nineteenth Century U.S."
+- Commentator: Joseph McCartin
 
 
 ### Paper session 3, 1:30--2:30 p.m.
 
-Session 3.1 
+Session 3.1 (Founders Hall 113) 
 
 - Rachel Bohlman and Suzanna Krivulskaya, "Visualizing Late Eighteenth-Century Maryland Catholic Slaveholding"
 - Anne Ruderman, Mark Heller, and Harry Xue, "Royal African Company Networks" 
+- Commentator: Abby Schreiber
 
-Session 3.2 
+Session 3.2 (Founders Hall 311)  
 
 - Shawn Martin, "Topic Modeling and Textual Analysis of American Scientific Journals, 1818–1922"
+- Commentator: Jessica Linker
 
 ### Paper session 4, 3:00--4:15 p.m.
 
-Session 4.1
+Session 4.1 (Founders Hall 113)
 
 - Harmony Bench and Kate Elswit, "Interpreting Touring Data for Dance History"
 - Scott Saul and Tessa Rissacher, "'For the Love of People': Berkeley’s Rainbow Sign and the Secret History of the Black Arts Movement"
 - Lauren Tilton, "Race and Place: Dialect and the Construction of Southern Identity in the FWP Slave Narratives"
+- Commentator: Suzanne Smith
 
 ### Venue and lodging
 


### PR DESCRIPTION
Building and previewing happen for every change on the site.
This commit changes the dependencies so those tasks are executed
in Ruby via Make, and not via Gulp, which was broken.

Only the generation of the CSS should depend on Gulp now.

Also adds a `deploy` task to deploy to dev and a `deploy-production` task to deploy to production.

Fixes #18 
Fixes #14 