### PR TITLE
remove old dependency on Foundation and motion-ui assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,7 @@ ENV HUGO_BUILD_ARGS=$hugobuildargs
 WORKDIR /app
 COPY . .
 
-# Legacy devDependencies (node-sass/gulp) aren't used for the Hugo build;
-# --ignore-scripts skips their postinstall compilation.
-RUN npm ci --ignore-scripts
-
-# Hugo's Dart Sass doesn't resolve node_modules imports, so stage
-# Foundation SCSS sources where Hugo's asset pipeline can find them.
-RUN mkdir -p assets/vendor && \
-    cp -r node_modules/foundation-sites assets/vendor/ && \
-    cp -r node_modules/motion-ui assets/vendor/
-
+RUN npm ci
 RUN hugo ${HUGO_BUILD_ARGS}
 
 FROM stagex/user-caddy


### PR DESCRIPTION
This pull request updates the Docker build process to ensure that all npm install scripts are executed and simplifies the staging of SCSS dependencies for Hugo. The main change is the removal of the `--ignore-scripts` flag from the `npm ci` command, which allows any necessary postinstall scripts to run.

**Build process updates:**

* Removed the `--ignore-scripts` flag from the `npm ci` command in the `Dockerfile`, ensuring that all npm lifecycle scripts (including postinstall) are executed during the build.
* Removed the manual copying of `foundation-sites` and `motion-ui` SCSS sources to the `assets/vendor` directory, as this step is no longer needed or is being handled differently.