### PR TITLE
Fix Docker build dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ ENV HUGO_BUILD_ARGS=$hugobuildargs
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+# The legacy Gulp dependencies are not used by the Hugo build. In particular,
+# gulp-sass pulls in deprecated node-sass, whose install script requires a
+# native build toolchain that is intentionally absent from this image.
+RUN npm ci --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
## Summary

- install the existing npm dependency tree without running lifecycle scripts
- document why the legacy Gulp and `node-sass` install scripts are unnecessary for the Hugo build

## Root cause

A recent Dockerfile change replaced `npm ci --ignore-scripts` with plain `npm ci`. That caused the unused `gulp-sass@3.1.0` dependency to run the deprecated `node-sass@4.5.3` native build, which fails because the StageX Node image intentionally does not include Python and the native compilation toolchain.

## Impact

The production Docker build can install Foundation and Motion UI sources for Hugo without attempting to compile `node-sass`. Hugo Extended remains responsible for compiling the site's SCSS through its `toCSS` pipeline.

## Validation

- `git diff --check`
- `npm ci --ignore-scripts --dry-run`

A full local Docker build was not used as the final check because the production StageX images target Linux/AMD64 and the local Docker host uses a different architecture.
